### PR TITLE
feat: support for dev domain

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,8 +12,8 @@ app.use(
   cors({
     origin: [
       "http://localhost:8081",
-      "podcasts.psmarcin.me",
-      "https://yt.psmarcin.me"
+      "https://yt.psmarcin.me",
+      "https://yt.psmarcin.dev"
     ]
   })
 );


### PR DESCRIPTION
### Context

Allow `yt.psmarcin.dev` to access api (CORS)

Closes: #

### Changes

- [x] Allow `yt.psmarcin.dev` to access api (CORS)

### Test

1. `nvm use && npm ci && npm run dev`
1. `GET https://yt.psmarcin.dev`

### Expect

<!-- What is expected behavior -->

1. CI :green_apple:
1. Can get results
