### PR TITLE
feat: use extension in video links

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -98,4 +98,9 @@ router.get(
   }
 );
 
+// support old links without extension
+router.get("/video/:videoId", (req, res) => {
+  res.redirect(`/video/${req.params.videoId}.mp4`);
+});
+
 export default router;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,9 +2,14 @@ import Boom from "boom";
 import { NextFunction, Request, Response, Router } from "express";
 import Joi, { JoiObject, ValidationResult } from "joi";
 import log from "./log";
-import { IFeedOptions } from './routes.interface'
+import { IFeedOptions } from "./routes.interface";
 import { getRedirectLink } from "./video/index";
-import { get, getAll as getAllChannels, serialize, serializeJSON } from "./youtube/channel";
+import {
+  get,
+  getAll as getAllChannels,
+  serialize,
+  serializeJSON
+} from "./youtube/channel";
 import { IChannel } from "./youtube/channel.interface";
 import { getAll, serialize as videoSerialize } from "./youtube/video";
 import { IVideo } from "./youtube/video.interface";
@@ -13,63 +18,84 @@ const startedAt = new Date();
 
 const feedOptionsSchema: JoiObject = Joi.object().keys({
   channelId: Joi.string().required(),
-  count: Joi.number().optional().default(10).max(50).min(1),
+  count: Joi.number()
+    .optional()
+    .default(10)
+    .max(50)
+    .min(1),
   q: Joi.string().optional()
-})
-
-router.get("/", (req: Request, res: Response): void => {
-  res.json({
-    up: startedAt.toUTCString(),
-  });
 });
 
-router.get("/channels", async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { q } = req.query;
-    const channels = await getAllChannels(q);
-    const serialized = serializeJSON(channels);
-    res.json(serialized);
-  } catch (error) {
-    next(Boom.badRequest(error.message));
+router.get(
+  "/",
+  (req: Request, res: Response): void => {
+    res.json({
+      up: startedAt.toUTCString()
+    });
   }
-});
+);
 
-router.get("/feed/channel/:channelId", async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  log.info(`[SERVER] ChannelID: ${req.params.channelId}`);
-  const options: IFeedOptions = {
-    channelId: req.params.channelId,
-    count: req.query.count,
-    q: req.query.search,
-  }
-  const validationResult: ValidationResult<IFeedOptions> = Joi.validate(options, feedOptionsSchema);
-
-  if (validationResult.error) {
-    return next(Boom.badRequest("ChannelId is not valid"));
-  }
-  try {
-    const options = validationResult.value;
-    const channel: IChannel = await get(options.channelId);
-    const videos: IVideo[] = await getAll(options);
-    const serializedVideos = videoSerialize(videos);
-    const serializedChannel = serialize(channel, serializedVideos);
-    res.header({ "content-type": "application/xml" }).send(serializedChannel.end({ pretty: true }));
-  } catch (error) {
-    next(error);
-  }
-});
-
-router.get("/video/:videoId", async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  try {
-    const { videoId } = req.params;
-    if (!videoId) {
-      throw Boom.badRequest("VideoId is required!");
+router.get(
+  "/channels",
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { q } = req.query;
+      const channels = await getAllChannels(q);
+      const serialized = serializeJSON(channels);
+      res.json(serialized);
+    } catch (error) {
+      next(Boom.badRequest(error.message));
     }
-    const url = await getRedirectLink(videoId);
-    res.status(302);
-    res.redirect(url);
-  } catch (error) {
-    next(error);
   }
-});
+);
+
+router.get(
+  "/feed/channel/:channelId",
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    log.info(`[SERVER] ChannelID: ${req.params.channelId}`);
+    const options: IFeedOptions = {
+      channelId: req.params.channelId,
+      count: req.query.count,
+      q: req.query.search
+    };
+    const validationResult: ValidationResult<IFeedOptions> = Joi.validate(
+      options,
+      feedOptionsSchema
+    );
+
+    if (validationResult.error) {
+      return next(Boom.badRequest("ChannelId is not valid"));
+    }
+    try {
+      const options = validationResult.value;
+      const channel: IChannel = await get(options.channelId);
+      const videos: IVideo[] = await getAll(options);
+      const serializedVideos = videoSerialize(videos);
+      const serializedChannel = serialize(channel, serializedVideos);
+      res
+        .header({ "content-type": "application/xml" })
+        .send(serializedChannel.end({ pretty: true }));
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+router.get(
+  "/video/:videoId.mp4",
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const { videoId } = req.params;
+      if (!videoId) {
+        throw Boom.badRequest("VideoId is required!");
+      }
+      const url = await getRedirectLink(videoId);
+      res.status(302);
+      res.redirect(url);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
 
 export default router;

--- a/src/youtube/video.ts
+++ b/src/youtube/video.ts
@@ -94,33 +94,33 @@ export function serialize(items: IVideo[]): object[] {
 
 function serializeItem(item: IVideo, order: number): object {
   return {
-    guid: {
-      "@isPermalink": false,
-      "#text": item.id
-    },
-    title: item.title,
-    link: `${VIDEO_BASE_URL}${item.id}`,
     description: item.description,
-    pubDate: item.publishedAt.toISOString(),
     enclosure: {
-      "@url": `${VIDEO_DIRECT_BASE_URL}${item.id}`,
+      "@length": item.videoDetails.contentLength || 0,
       "@type": item.videoDetails.contentType || "unknown",
-      "@length": item.videoDetails.contentLength || 0
+      "@url": `${VIDEO_DIRECT_BASE_URL}${item.id}.mp4`
+    },
+    guid: {
+      "#text": item.id,
+      "@isPermalink": false
     },
     "itunes:author": item.channelId,
-    "itunes:subtitle": item.title,
-    "itunes:summary": item.description,
+    "itunes:duration": item.duration,
+    "itunes:explicit": "no",
     "itunes:image": {
       "@href": item.thumbnails.high.url
     },
-    "itunes:duration": item.duration,
-    "itunes:explicit": "no",
-    "itunes:order": order
+    "itunes:order": order,
+    "itunes:subtitle": item.title,
+    "itunes:summary": item.description,
+    link: `${VIDEO_BASE_URL}${item.id}`,
+    pubDate: item.publishedAt.toISOString(),
+    title: item.title
   };
 }
 
 async function getVideoDetails(videoId: string): Promise<IVideoDetails> {
-  const response: any = await head(`${VIDEO_DIRECT_BASE_URL}${videoId}`);
+  const response: any = await head(`${VIDEO_DIRECT_BASE_URL}${videoId}.mp4`);
   return {
     contentLength: response["content-length"],
     contentType: response["content-type"]

--- a/tests/get-video.spec.ts
+++ b/tests/get-video.spec.ts
@@ -4,13 +4,20 @@ import { app } from "./../src/app";
 describe("GET /video", () => {
   it("should get redirect link", done => {
     supertest(app)
+      .get("/video/NtQkz0aRDe8.mp4")
+      .expect(302)
+      .end(done);
+  });
+  it("should get redirect link to old route", done => {
+    supertest(app)
       .get("/video/NtQkz0aRDe8")
       .expect(302)
       .end(done);
   });
+
   it("should get return nothing", done => {
     supertest(app)
-      .get("/video/NOT_VALID_VIDEO_ID")
+      .get("/video/NOT_VALID_VIDEO_ID.mp4")
       .expect(400)
       .end(done);
   });


### PR DESCRIPTION
### Context

Use extension in video route

### Changes

- [x] Change video route (use `.mp4` extension)
- [x] Serve new links for audio files

### Test

1. `nvm use && npm ci && npm run dev`
1. `GET http://localhost:8080/video/bbgJ8W24lEI.mp4`

### Expect

<!-- What is expected behavior -->

1. CI :green_apple:
1. Request success
