### PR TITLE
 feat: add search query to title

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -67,9 +67,9 @@ router.get(
       return next(Boom.badRequest("ChannelId is not valid"));
     }
     try {
-      const options = validationResult.value;
-      const channel: IChannel = await get(options.channelId);
-      const videos: IVideo[] = await getAll(options);
+      const values: IFeedOptions = validationResult.value;
+      const channel: IChannel = await get(values.channelId, values.q);
+      const videos: IVideo[] = await getAll(values);
       const serializedVideos = videoSerialize(videos);
       const serializedChannel = serialize(channel, serializedVideos);
       res

--- a/src/youtube/channel.ts
+++ b/src/youtube/channel.ts
@@ -12,7 +12,10 @@ import request from "./request";
 const CHANNEL_BASE_URL = `https://youtube.com/channel/`;
 const TRANSCODE_BASE_URL = `https://transcoder.plex.tv/photo?height=1500&minSize=1&width=1500&upscale=1&url=`;
 
-export async function get(channelId: string): Promise<IChannel> {
+export async function get(
+  channelId: string,
+  query: string | undefined
+): Promise<IChannel> {
   let response: any;
 
   try {
@@ -34,6 +37,7 @@ export async function get(channelId: string): Promise<IChannel> {
 
   const snippet: ISnippet = resp.items[0].snippet;
 
+  const title = query ? `${snippet.title} - ${query}` : snippet.title;
   const channel: IChannel = {
     country: snippet.country,
     customUrl: snippet.customUrl,
@@ -45,7 +49,7 @@ export async function get(channelId: string): Promise<IChannel> {
       high: snippet.thumbnails.high.url,
       medium: snippet.thumbnails.medium.url
     },
-    title: snippet.title
+    title
   };
 
   return channel;


### PR DESCRIPTION
### Context
It's useful to have search query string in title in app. Mostly for multiple feeds from one channel

Closes: #9 



### Changes

- [x] Use search query string in channel title

### Test

1. `nvm use && npm ci && npm run dev`
1. `GET :8080/feed/channel/UC_7PqixGIdE-jjoHKMPYpGA?search=test`

### Expect

<!-- What is expected behavior -->

1. CI :green_apple:
1. Expect title that contains `test` string at the end
