### PR TITLE
test(e2e): feed and channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "deploy:ci": "now -t ${NOWSHTOKEN} && now alias podcasts.psmarcin.me -t ${NOWSHTOKEN}",
     "dev": "nodemon | pino-pretty",
     "start": "node ./lib/index.js",
-    "lint": "prettier --write ./src/**/*.ts",
+    "lint": "prettier --write ./src/**/*.ts ./tests/*.ts",
     "test": "jest ./src/**/*.spec.ts",
     "test:integration": "jest ./tests/*.spec.ts",
     "test:watch": "npm test -- --watch"
@@ -46,6 +46,7 @@
     "@types/request-promise-native": "1.0.15",
     "@types/supertest": "2.0.7",
     "@types/xmlbuilder": "0.0.34",
+    "fast-xml-parser": "3.12.16",
     "husky": "1.3.1",
     "jest": "24.5.0",
     "lint-staged": "8.1.5",

--- a/tests/get-channel.spec.ts
+++ b/tests/get-channel.spec.ts
@@ -1,0 +1,51 @@
+import xmlParser from "fast-xml-parser";
+import nock from "nock";
+import supertest from "supertest";
+import { app } from "./../src/app";
+
+describe("GET /feed/channel/:channelId", () => {
+  beforeAll(() => {
+    const videoRegex = /video.*.mp4$/;
+    nock("http://localhost:8080")
+      .get(videoRegex)
+      .reply(200)
+      .persist();
+    nock("http://localhost:8080")
+      .head(videoRegex)
+      .reply(200)
+      .persist();
+  });
+
+  it("should get 5 elements in response", async () => {
+    const channelId = "UCmrlqFIK_QQCsr3FRHa3OKw";
+    const response = await supertest(app)
+      .get(`/feed/channel/${channelId}`)
+      .expect(200);
+    const xml = xmlParser.parse(response.text);
+
+    expect(xml).toHaveProperty(
+      "rss.channel",
+      expect.objectContaining({
+        generator: "youtube-goes-podcast@v1.0.0",
+        "itunes:author": "flaretv",
+        "itunes:category": "",
+        "itunes:explicit": "clean",
+        "itunes:image": "",
+        "itunes:type": "episodic",
+        language: "us",
+        ttl: 60
+      })
+    );
+
+    expect(xml).toHaveProperty(
+      "rss.channel.item",
+      expect.arrayContaining([
+        expect.objectContaining({
+          "itunes:duration": 0,
+          "itunes:explicit": "no",
+          "itunes:image": ""
+        })
+      ])
+    );
+  });
+});

--- a/tests/get-channels.spec.ts
+++ b/tests/get-channels.spec.ts
@@ -1,0 +1,46 @@
+import supertest from "supertest";
+import { app } from "./../src/app";
+
+describe("GET /channels", () => {
+  it("should get 5 elements in response", async () => {
+    const response = await supertest(app)
+      .get("/channels?q=PewDiePie")
+      .expect(200);
+    expect(response.body).toHaveLength(5);
+    expect(response).toHaveProperty(
+      "body",
+      expect.arrayContaining([
+        expect.objectContaining({
+          channelId: expect.any(String),
+          thumbnail: expect.any(String),
+          title: expect.any(String)
+        })
+      ])
+    );
+  });
+
+  it("should get 0 elements in response", async () => {
+    const response = await supertest(app)
+      .get("/channels?q=12hk4j12k4h12h3kj123h123jkb1n23jkb12k3jk1b23kjl1")
+      .expect(200);
+    expect(response.body).toHaveLength(0);
+    expect(response).toHaveProperty("body", []);
+  });
+
+  it("should get top 5 elements in response for no query", async () => {
+    const response = await supertest(app)
+      .get("/channels")
+      .expect(200);
+    expect(response.body).toHaveLength(5);
+    expect(response).toHaveProperty(
+      "body",
+      expect.arrayContaining([
+        expect.objectContaining({
+          channelId: expect.any(String),
+          thumbnail: expect.any(String),
+          title: expect.any(String)
+        })
+      ])
+    );
+  });
+});


### PR DESCRIPTION
### Context
End to end tests for `get-channel` and `get-feed` routes.

Related: #10 

### Changes

- [x] Setup `GET /channels?q=` e2e tests
- [x] Setup `GET /feed/channel/:channelId` e2e tests
- [x] Link `/tests/` fiels

### Test

<!-- How to test, what you need and how to setup test environment -->

1. `nvm use && npm ci && npm run test:integration`
1. ...

### Expect

<!-- What is expected behavior -->

1. CI :green_apple:
